### PR TITLE
improve one liner to work with sub namespaces

### DIFF
--- a/generator/skeleton/composer.json
+++ b/generator/skeleton/composer.json
@@ -4,7 +4,7 @@
   },
   "autoload": {
     "psr-0": {
-      "###NAMESPACE###\\": "include/"
+      "Test\\Partner\\": "include/"
     }
   }
 }

--- a/generator/skeleton/composer.json
+++ b/generator/skeleton/composer.json
@@ -4,7 +4,7 @@
   },
   "autoload": {
     "psr-0": {
-      "Test\\Partner\\": "include/"
+      "###NAMESPACE_ESCAPED###\\": "include/"
     }
   }
 }

--- a/generator/slim-bootstrap-generator
+++ b/generator/slim-bootstrap-generator
@@ -10,6 +10,7 @@ fi
 namespace="$1"
 namespace_lower="$(echo ${namespace} | tr '[:upper:]' '[:lower:]' | sed 's:\\:-:g')"
 namespace_folder="$(echo ${namespace} | sed 's:\\:/:g')"
+namespace_escaped="$(echo ${namespace} | sed 's:\\:\\\\\\\\:g')"
 namespace="$(echo ${namespace} | sed 's:\\:\\\\:g')"
 
 echo -e "\e[1mGenerating skeleton for \e[34m${namespace}\e[1;39m ...\e[0m"
@@ -26,6 +27,7 @@ for template in $(find "${basefolder}" -type f -not -name ".lock"); do
     mkdir -p "${dir}"
 
     sed "s:###NAMESPACE###:${namespace}:g" "${template}" > "${file}"
+    sed -i -e "s:###NAMESPACE_ESCAPED###:${namespace_escaped}:g" "${file}"
     sed -i -e "s:###NAMESPACE_LOWER###:${namespace_lower}:g" "${file}"
 done
 

--- a/generator/slim-bootstrap-generator
+++ b/generator/slim-bootstrap-generator
@@ -8,13 +8,15 @@ if [ $# -ne 1 ]; then
 fi
 
 namespace="$1"
-namespace_lower="$(echo ${namespace} | tr '[:upper:]' '[:lower:]')"
+namespace_lower="$(echo ${namespace} | tr '[:upper:]' '[:lower:]' | sed 's:\\:-:g')"
+namespace_folder="$(echo ${namespace} | sed 's:\\:/:g')"
+namespace="$(echo ${namespace} | sed 's:\\:\\\\:g')"
 
 echo -e "\e[1mGenerating skeleton for \e[34m${namespace}\e[1;39m ...\e[0m"
 
 for template in $(find "${basefolder}" -type f -not -name ".lock"); do
     file=${template//${basefolder}/}
-    file=$(echo ${file} | sed "s/###NAMESPACE###/${namespace}/")
+    file=$(echo ${file} | sed "s:###NAMESPACE###:${namespace_folder}:")
     file="./${file}"
 
     echo "creating ${file} from ${template} ..."
@@ -25,7 +27,6 @@ for template in $(find "${basefolder}" -type f -not -name ".lock"); do
 
     sed "s:###NAMESPACE###:${namespace}:g" "${template}" > "${file}"
     sed -i -e "s:###NAMESPACE_LOWER###:${namespace_lower}:g" "${file}"
-    sed -i -e "s:###BASEDIRECTORY###:$(pwd):g" "${file}"
 done
 
 for directory in $(find "${basefolder}" -type f -name ".lock"); do


### PR DESCRIPTION
Previously the generator (which is used in the one liner) had problems if you had a namespace like "\Some\Project" because it stripped the "\" from the name.

This PR fixes that.
