### PR TITLE
Logging improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## 1.1.0
+ - bugfix: generator can now work with sub namespaces
+ - bugfix: payload is passed again to endpoints when using http method `POST` or `PUT`
+ - feature: `\SlimBootstrap\Exception` can now define the log level with which it wants to be logged
+~~~php
+class Exception extends \Exception
+{
+    public function __construct($message = '', $code = 0, $logLevel = \Slim\Log::ERROR);
+}
+~~~

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ These endpoints should implement one of the _CollectionEndpoint_ interfaces loca
 
 **Resource endpoints**
 
-These endpoints should implement one of the _RessurceEndpoint_ interfaces located under [\SlimBootstrap\Endpoint](src/SlimBootstrap/Endpoint). It will then get an array of the parameters in the URL the resource is identified with and if it is not a GET endpoint an array of data which will be the payload send with the request. The endpoint should return a [\SlimBootstrap\DataObject](src/SlimBootstrap/DataObject.php) and it should throw a [\SlimBootstrap\Exception](src/SlimBootstrap/Exception.php) if the endpoint encounters an error. The message of that exception will be printed out as result and the code will be used as HTTP status code.
+These endpoints should implement one of the _RessurceEndpoint_ interfaces located under [\SlimBootstrap\Endpoint](src/SlimBootstrap/Endpoint). It will then get an array of the parameters in the URL the resource is identified with and if it is not a GET endpoint an array of data which will be the payload send with the request. The endpoint should return a [\SlimBootstrap\DataObject](src/SlimBootstrap/DataObject.php) and it should throw a [\SlimBootstrap\Exception](src/SlimBootstrap/Exception.php) if the endpoint encounters an error. When an exception is thrown, the optional third parameter defines the log level with which this exception will be logged. The default is "ERROR". The message of that exception will be printed out as result and the code will be used as HTTP status code.
 
 ### Supported HTTP methods
 At the moment the framework supports the following HTTP methods:

--- a/src/SlimBootstrap/Bootstrap.php
+++ b/src/SlimBootstrap/Bootstrap.php
@@ -173,8 +173,7 @@ class Bootstrap
                     $this->_app->request,
                     $this->_app->response,
                     $this->_app->response->headers,
-                    $this->_applicationConfig['shortName'],
-                    $this->_app->getLog()
+                    $this->_applicationConfig['shortName']
                 );
             $this->_responseOutputWriter = $responseOutputWriterFactory->create(
                 $this->_app->request->headers->get('Accept')
@@ -228,7 +227,8 @@ class Bootstrap
                 $this->_app->getLog()->info('access granted');
             }
         } catch (SlimBootstrap\Exception $e) {
-            $this->_app->getLog()->error(
+            $this->_app->getLog()->log(
+                $e->getLogLevel(),
                 $e->getCode() . ' - ' . $e->getMessage()
             );
             $this->_app->response->setStatus($e->getCode());
@@ -282,7 +282,8 @@ class Bootstrap
                         $endpoint->$type($params, $app->$type())
                     );
                 } catch (SlimBootstrap\Exception $e) {
-                    $app->getLog()->error(
+                    $app->getLog()->log(
+                        $e->getLogLevel(),
                         $e->getCode() . ' - ' . $e->getMessage()
                     );
                     $app->response->setStatus($e->getCode());
@@ -344,7 +345,8 @@ class Bootstrap
                         $endpoint->$type($params, $app->$type())
                     );
                 } catch (SlimBootstrap\Exception $e) {
-                    $app->getLog()->error(
+                    $app->getLog()->log(
+                        $e->getLogLevel(),
                         $e->getCode() . ' - ' . $e->getMessage()
                     );
                     $app->response->setStatus($e->getCode());

--- a/src/SlimBootstrap/Exception.php
+++ b/src/SlimBootstrap/Exception.php
@@ -1,6 +1,8 @@
 <?php
 namespace SlimBootstrap;
 
+use \Slim;
+
 /**
  * This class represents the basic API exception to be thrown if an error
  * occurs.
@@ -9,5 +11,31 @@ namespace SlimBootstrap;
  */
 class Exception extends \Exception
 {
-    // nothing to do
+    /**
+     * @var int
+     */
+    private $_logLevel = Slim\Log::ERROR;
+
+    /**
+     * @param string $message
+     * @param int    $code
+     * @param int    $logLevel
+     */
+    public function __construct(
+        $message = '',
+        $code = 0,
+        $logLevel = Slim\Log::ERROR
+    ) {
+        parent::__construct($message, $code);
+
+        $this->_logLevel = $logLevel;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLogLevel()
+    {
+        return $this->_logLevel;
+    }
 }


### PR DESCRIPTION
The `\SlimBootstrap\Exception` can now take the `\Slim\Log` level as optional third parameter. This will then be used as log level when the exception is logged. The default value is `\Slim\Log::ERROR`.
