### PR TITLE
Improve logging

### DIFF
--- a/src/SlimBootstrap/Authentication/Oauth.php
+++ b/src/SlimBootstrap/Authentication/Oauth.php
@@ -50,7 +50,11 @@ class Oauth implements SlimBootstrap\Authentication
         if (null === $result
             || false === array_key_exists('entity_id', $result)
         ) {
-            throw new SlimBootstrap\Exception('Access token invalid', 401);
+            throw new SlimBootstrap\Exception(
+                'Access token invalid',
+                401,
+                \Slim\Log::WARN
+            );
         }
 
         return $result['entity_id'];

--- a/src/SlimBootstrap/Authentication/Oauth.php
+++ b/src/SlimBootstrap/Authentication/Oauth.php
@@ -94,14 +94,29 @@ class Oauth implements SlimBootstrap\Authentication
         if (0 !== $curlErrno) {
             $this->_logger->addError(
                 'curl error (' . $curlErrno . '): ' . $curlError
+                . ' url: ' . $url
             );
         }
 
-        if ($responseCode >= 400) {
-            $this->_logger->addError('curl call error: ' . $responseCode);
-
+        if ($responseCode >= 500) {
+            $this->_logger->addError(
+                'curl call error: ' . $responseCode . ' url: ' . $url
+            );
+        } elseif ($responseCode >= 400) {
+            if ($responseCode === 404) {
+                $this->_logger->addRecord(
+                    Monolog\Logger::WARNING,
+                    'curl call: ' . $responseCode . ' url: ' . $url
+                );
+            } else {
+                $this->_logger->addWarning(
+                    'curl call warning: ' . $responseCode . ' url: ' . $url
+                );
+            }
         } elseif ($responseCode >= 300) {
-            $this->_logger->addWarning('curl call warning: ' . $responseCode);
+            $this->_logger->addWarning(
+                'curl call warning: ' . $responseCode . ' url: ' . $url
+            );
         }
 
         $this->_logger->addDebug(

--- a/src/SlimBootstrap/Authentication/Oauth.php
+++ b/src/SlimBootstrap/Authentication/Oauth.php
@@ -102,17 +102,6 @@ class Oauth implements SlimBootstrap\Authentication
             $this->_logger->addError(
                 'curl call error: ' . $responseCode . ' url: ' . $url
             );
-        } elseif ($responseCode >= 400) {
-            if ($responseCode === 404) {
-                $this->_logger->addRecord(
-                    Monolog\Logger::WARNING,
-                    'curl call: ' . $responseCode . ' url: ' . $url
-                );
-            } else {
-                $this->_logger->addWarning(
-                    'curl call warning: ' . $responseCode . ' url: ' . $url
-                );
-            }
         } elseif ($responseCode >= 300) {
             $this->_logger->addWarning(
                 'curl call warning: ' . $responseCode . ' url: ' . $url


### PR DESCRIPTION
- 401 thrown form restapi authentication (Oauth) should be logged as WARNING
- improve error logging at oauth caller
