### PR TITLE
fix php error when no authentication is used

### DIFF
--- a/src/SlimBootstrap/Hook.php
+++ b/src/SlimBootstrap/Hook.php
@@ -54,8 +54,8 @@ class Hook
     public function __construct(
         array $applicationConfig,
         Slim\Slim $app,
-        SlimBootstrap\Authentication $authentication,
-        array $aclConfig
+        SlimBootstrap\Authentication $authentication = null,
+        array $aclConfig = null
     ) {
         $this->_applicationConfig = $applicationConfig;
         $this->_app               = $app;


### PR DESCRIPTION
when no authentication was used the last refactoring caused a fatal error.
