### PR TITLE
Outputwriter plain data

### DIFF
--- a/src/SlimBootstrap/Bootstrap.php
+++ b/src/SlimBootstrap/Bootstrap.php
@@ -220,9 +220,23 @@ class Bootstrap
                     );
                 }
             } else {
-                $outputWriter->write(
-                    $endpoint->$type($params, $this->_app->request->$type())
+                $data = $endpoint->$type(
+                    $params, $this->_app->request->$type()
                 );
+
+                if ($endpoint instanceof SlimBootstrap\Endpoint\PlainData) {
+                    if ($outputWriter instanceof SlimBootstrap\ResponseOutputWriterPlainData) {
+                        $outputWriter->writePlain($data);
+                    } else {
+                        throw new SlimBootstrap\Exception(
+                            'media type does not support plain data writing',
+                            406,
+                            Slim\Log::WARN
+                        );
+                    }
+                } else {
+                    $outputWriter->write($data);
+                }
             }
         } catch (SlimBootstrap\Exception $e) {
             $this->_app->getLog()->log(

--- a/src/SlimBootstrap/Endpoint/PlainData.php
+++ b/src/SlimBootstrap/Endpoint/PlainData.php
@@ -1,0 +1,12 @@
+<?php
+namespace SlimBootstrap\Endpoint;
+
+/**
+ * Interface PlainData
+ *
+ * @package SlimBootstrap\Endpoint
+ */
+interface PlainData
+{
+
+}

--- a/src/SlimBootstrap/Hook.php
+++ b/src/SlimBootstrap/Hook.php
@@ -100,7 +100,8 @@ class Hook
     public function requestPath()
     {
         $this->_app->getLog()->debug(
-            'Request path: ' . $this->_app->request->getPathInfo()
+            'Request: ' . $this->_app->request->getMethod()
+            . ' - ' . $this->_app->request->getPathInfo()
         );
     }
 

--- a/src/SlimBootstrap/ResponseOutputWriter/Json.php
+++ b/src/SlimBootstrap/ResponseOutputWriter/Json.php
@@ -57,6 +57,10 @@ class Json implements SlimBootstrap\ResponseOutputWriter,
      */
     public function writePlain(array $data, $statusCode = 200)
     {
+        $this->_headers->set(
+            'Content-Type',
+            'application/json; charset=UTF-8'
+        );
         $this->_response->setStatus($statusCode);
         $this->_response->setBody($this->_jsonEncode($data));
     }

--- a/src/SlimBootstrap/ResponseOutputWriter/Json.php
+++ b/src/SlimBootstrap/ResponseOutputWriter/Json.php
@@ -10,7 +10,8 @@ use \Slim;
  *
  * @package SlimBootstrap\ResponseOutputWriter
  */
-class Json implements SlimBootstrap\ResponseOutputWriter
+class Json implements SlimBootstrap\ResponseOutputWriter,
+                      SlimBootstrap\ResponseOutputWriterPlainData
 {
     /**
      * The Slim request object.
@@ -48,6 +49,16 @@ class Json implements SlimBootstrap\ResponseOutputWriter
         $this->_request  = $request;
         $this->_response = $response;
         $this->_headers  = $headers;
+    }
+
+    /**
+     * @param array $data
+     * @param int   $statusCode
+     */
+    public function writePlain(array $data, $statusCode = 200)
+    {
+        $this->_response->setStatus($statusCode);
+        $this->_response->setBody($this->_jsonEncode($data));
     }
 
     /**

--- a/src/SlimBootstrap/ResponseOutputWriterPlainData.php
+++ b/src/SlimBootstrap/ResponseOutputWriterPlainData.php
@@ -1,0 +1,31 @@
+<?php
+namespace SlimBootstrap;
+
+use \SlimBootstrap;
+use \Slim;
+
+/**
+ * Interface ResponseOutputWriterPlainData
+ *
+ * @package SlimBootstrap
+ */
+interface ResponseOutputWriterPlainData
+{
+    /**
+     * @param Slim\Http\Request  $request  The Slim request instance
+     * @param Slim\Http\Response $response The Slim response instance
+     * @param Slim\Http\Headers  $headers  The Slim request header instance
+     * @param string             $shortName
+     */
+    public function __construct(
+        Slim\Http\Request $request,
+        Slim\Http\Response $response,
+        Slim\Http\Headers $headers,
+        $shortName
+    );
+
+    /**
+     * @param array $data
+     */
+    public function writePlain(array $data);
+}

--- a/tests/SlimBootstrap/ResponseOutputWriter/JsonTest.php
+++ b/tests/SlimBootstrap/ResponseOutputWriter/JsonTest.php
@@ -182,6 +182,13 @@ class JsonTest extends \PHPUnit_Framework_TestCase
             )
             ->will($this->returnValue('{"mockKey": "mockValue"}'));
 
+        $this->_mockHeaders
+            ->expects($this->exactly(1))
+            ->method('set')
+            ->with(
+                $this->equalTo('Content-Type'),
+                $this->equalTo('application/json; charset=UTF-8')
+            );
         $this->_mockResponse
             ->expects($this->exactly(1))
             ->method('setStatus')

--- a/tests/SlimBootstrap/ResponseOutputWriter/JsonTest.php
+++ b/tests/SlimBootstrap/ResponseOutputWriter/JsonTest.php
@@ -11,22 +11,22 @@ use \SlimBootstrap\DataObject;
 class JsonTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Slim\Http\Request
      */
     private $_mockRequest = null;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Slim\Http\Response
      */
     private $_mockResponse = null;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Slim\Http\Headers
      */
     private $_mockHeaders = null;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject|\SlimBootstrap\ResponseOutputWriter\Json
      */
     private $_jsonTestOutputWriter = null;
 
@@ -165,6 +165,36 @@ class JsonTest extends \PHPUnit_Framework_TestCase
                     array()
                 ),
             ),
+        );
+    }
+
+    public function testWritePlain()
+    {
+        $this->_jsonTestOutputWriter
+            ->expects($this->exactly(1))
+            ->method('_jsonEncode')
+            ->with(
+                $this->equalTo(
+                    array(
+                        'mockKey' => 'mockValue',
+                    )
+                )
+            )
+            ->will($this->returnValue('{"mockKey": "mockValue"}'));
+
+        $this->_mockResponse
+            ->expects($this->exactly(1))
+            ->method('setStatus')
+            ->with($this->equalTo(200));
+        $this->_mockResponse
+            ->expects($this->exactly(1))
+            ->method('setBody')
+            ->with($this->equalTo('{"mockKey": "mockValue"}'));
+
+        $this->_jsonTestOutputWriter->writePlain(
+            array(
+                'mockKey' => 'mockValue',
+            )
         );
     }
 }


### PR DESCRIPTION
We need a way to use slim-bootstrap without the internal DataObjects, because they were only introduced to be able to support hal+json output. In our case we need only plain json output and for that we want to reduce the amount of RAM needed.
